### PR TITLE
fix: remove context propogation as pointer

### DIFF
--- a/pkg/event_handler/github_event_notifier.go
+++ b/pkg/event_handler/github_event_notifier.go
@@ -48,7 +48,7 @@ func NewGithubEventNotifier(cfg *conf.GlobalConfig, clients *clients.Clients) Ev
 	}
 }
 
-func (gn *githubNotifier) Notify(ctx *context.Context, workflow *v1alpha1.Workflow) error {
+func (gn *githubNotifier) Notify(ctx context.Context, workflow *v1alpha1.Workflow) error {
 	fmt.Printf("Notifing workflow, %s\n", workflow.GetName())
 
 	repo, ok := workflow.GetLabels()["repo"]

--- a/pkg/event_handler/github_event_notifier_test.go
+++ b/pkg/event_handler/github_event_notifier_test.go
@@ -16,35 +16,35 @@ import (
 
 type mockGitProvider struct{}
 
-func (m *mockGitProvider) GetFile(ctx *context.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
+func (m *mockGitProvider) GetFile(ctx context.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) GetFiles(ctx *context.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
+func (m *mockGitProvider) GetFiles(ctx context.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) ListFiles(ctx *context.Context, repo string, branch string, path string) ([]string, error) {
+func (m *mockGitProvider) ListFiles(ctx context.Context, repo string, branch string, path string) ([]string, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) SetWebhook(ctx *context.Context, repo *string) (*git_provider.HookWithStatus, error) {
+func (m *mockGitProvider) SetWebhook(ctx context.Context, repo *string) (*git_provider.HookWithStatus, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) UnsetWebhook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *mockGitProvider) UnsetWebhook(ctx context.Context, hook *git_provider.HookWithStatus) error {
 	return nil
 }
 
-func (m *mockGitProvider) HandlePayload(ctx *context.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
+func (m *mockGitProvider) HandlePayload(ctx context.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) SetStatus(ctx *context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
+func (m *mockGitProvider) SetStatus(ctx context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
 	return nil
 }
 
-func (m *mockGitProvider) PingHook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *mockGitProvider) PingHook(ctx context.Context, hook *git_provider.HookWithStatus) error {
 	return nil
 }
 
@@ -202,7 +202,7 @@ func TestNotify(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Call the function being tested
-			err := gn.Notify(&ctx, test.workflow)
+			err := gn.Notify(ctx, test.workflow)
 
 			// Use assert to check the equality of the error
 			if test.wantedError != nil {

--- a/pkg/event_handler/main.go
+++ b/pkg/event_handler/main.go
@@ -15,7 +15,7 @@ func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig,
 				Operator: metav1.LabelSelectorOpExists},
 		},
 	}
-	watcher, err := clients.Workflows.Watch(&ctx, labelSelector)
+	watcher, err := clients.Workflows.Watch(ctx, labelSelector)
 	if err != nil {
 		log.Printf("[event handler] Failed to watch workflow error:%s", err)
 		return

--- a/pkg/event_handler/types.go
+++ b/pkg/event_handler/types.go
@@ -11,5 +11,5 @@ type EventHandler interface {
 }
 
 type EventNotifier interface {
-	Notify(ctx *context.Context, workflow *v1alpha1.Workflow) error
+	Notify(ctx context.Context, workflow *v1alpha1.Workflow) error
 }

--- a/pkg/event_handler/workflow_event_handler.go
+++ b/pkg/event_handler/workflow_event_handler.go
@@ -40,12 +40,12 @@ func (weh *workflowEventHandler) Handle(ctx context.Context, event *watch.Event)
 		return nil
 	}
 
-	err := weh.Notifier.Notify(&ctx, workflow)
+	err := weh.Notifier.Notify(ctx, workflow)
 	if err != nil {
 		return fmt.Errorf("failed to Notify workflow to git provider, error:%s\n", err)
 	}
 
-	err = weh.Clients.Workflows.UpdatePiperWorkflowLabel(&ctx, workflow.GetName(), "notified", string(workflow.Status.Phase))
+	err = weh.Clients.Workflows.UpdatePiperWorkflowLabel(ctx, workflow.GetName(), "notified", string(workflow.Status.Phase))
 	if err != nil {
 		return fmt.Errorf("error in workflow %s status patch: %s", workflow.GetName(), err)
 	}

--- a/pkg/git_provider/bitbucket.go
+++ b/pkg/git_provider/bitbucket.go
@@ -2,13 +2,13 @@ package git_provider
 
 import (
 	"bytes"
+	context2 "context"
 	"encoding/json"
 	"fmt"
 	"github.com/ktrysmt/go-bitbucket"
 	"github.com/quickube/piper/pkg/conf"
 	"github.com/quickube/piper/pkg/utils"
 	"github.com/tidwall/gjson"
-	"golang.org/x/net/context"
 	"io"
 	"log"
 	"net/http"
@@ -36,7 +36,7 @@ func NewBitbucketServerClient(cfg *conf.GlobalConfig) (Client, error) {
 	}, err
 }
 
-func (b BitbucketClientImpl) ListFiles(ctx *context.Context, repo string, branch string, path string) ([]string, error) {
+func (b BitbucketClientImpl) ListFiles(ctx context2.Context, repo string, branch string, path string) ([]string, error) {
 	var filesList []string
 	fileOptions := bitbucket.RepositoryFilesOptions{
 		Owner:    b.cfg.GitProviderConfig.OrgName,
@@ -58,7 +58,7 @@ func (b BitbucketClientImpl) ListFiles(ctx *context.Context, repo string, branch
 	return filesList, nil
 }
 
-func (b BitbucketClientImpl) GetFile(ctx *context.Context, repo string, branch string, path string) (*CommitFile, error) {
+func (b BitbucketClientImpl) GetFile(ctx context2.Context, repo string, branch string, path string) (*CommitFile, error) {
 	fileOptions := bitbucket.RepositoryFilesOptions{
 		Owner:    b.cfg.GitProviderConfig.OrgName,
 		RepoSlug: repo,
@@ -78,7 +78,7 @@ func (b BitbucketClientImpl) GetFile(ctx *context.Context, repo string, branch s
 	}, nil
 }
 
-func (b BitbucketClientImpl) GetFiles(ctx *context.Context, repo string, branch string, paths []string) ([]*CommitFile, error) {
+func (b BitbucketClientImpl) GetFiles(ctx context2.Context, repo string, branch string, paths []string) ([]*CommitFile, error) {
 	var commitFiles []*CommitFile
 	for _, path := range paths {
 		file, err := b.GetFile(ctx, repo, branch, path)
@@ -94,7 +94,7 @@ func (b BitbucketClientImpl) GetFiles(ctx *context.Context, repo string, branch 
 	return commitFiles, nil
 }
 
-func (b BitbucketClientImpl) SetWebhook(ctx *context.Context, repo *string) (*HookWithStatus, error) {
+func (b BitbucketClientImpl) SetWebhook(ctx context2.Context, repo *string) (*HookWithStatus, error) {
 	webhookOptions := &bitbucket.WebhooksOptions{
 		Owner:       b.cfg.GitProviderConfig.OrgName,
 		RepoSlug:    *repo,
@@ -139,12 +139,12 @@ func (b BitbucketClientImpl) SetWebhook(ctx *context.Context, repo *string) (*Ho
 	}, nil
 }
 
-func (b BitbucketClientImpl) UnsetWebhook(ctx *context.Context, hook *HookWithStatus) error {
+func (b BitbucketClientImpl) UnsetWebhook(ctx context2.Context, hook *HookWithStatus) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (b BitbucketClientImpl) HandlePayload(ctx *context.Context, request *http.Request, secret []byte) (*WebhookPayload, error) {
+func (b BitbucketClientImpl) HandlePayload(ctx context2.Context, request *http.Request, secret []byte) (*WebhookPayload, error) {
 	var webhookPayload *WebhookPayload
 	var buf bytes.Buffer
 
@@ -205,7 +205,7 @@ func (b BitbucketClientImpl) HandlePayload(ctx *context.Context, request *http.R
 	return webhookPayload, nil
 }
 
-func (b BitbucketClientImpl) SetStatus(ctx *context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
+func (b BitbucketClientImpl) SetStatus(ctx context2.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
 	commitOptions := bitbucket.CommitsOptions{
 		Owner:    b.cfg.GitProviderConfig.OrgName,
 		RepoSlug: *repo,
@@ -225,7 +225,7 @@ func (b BitbucketClientImpl) SetStatus(ctx *context.Context, repo *string, commi
 	return nil
 }
 
-func (b BitbucketClientImpl) PingHook(ctx *context.Context, hook *HookWithStatus) error {
+func (b BitbucketClientImpl) PingHook(ctx context2.Context, hook *HookWithStatus) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/git_provider/bitbucket_test.go
+++ b/pkg/git_provider/bitbucket_test.go
@@ -51,7 +51,7 @@ func TestBitbucketListFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Execute
-	actualContent, err := c.ListFiles(&ctx, "test-repo1", "branch1", ".workflows")
+	actualContent, err := c.ListFiles(ctx, "test-repo1", "branch1", ".workflows")
 	expectedContent := []string{"exit.yaml", "main.yaml"}
 
 	// Assert
@@ -159,7 +159,7 @@ func TestBitbucketSetStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			// Call the function being tested
-			err := c.SetStatus(&ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
+			err := c.SetStatus(ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
 
 			// Use assert to check the equality of the error
 			if test.wantedError != nil {

--- a/pkg/git_provider/github_test.go
+++ b/pkg/git_provider/github_test.go
@@ -63,7 +63,7 @@ func TestListFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Execute
-	actualContent, err := c.ListFiles(&ctx, "test-repo1", "branch1", ".workflows")
+	actualContent, err := c.ListFiles(ctx, "test-repo1", "branch1", ".workflows")
 	expectedContent := []string{"exit.yaml", "main.yaml"}
 
 	// Assert
@@ -179,7 +179,7 @@ func TestSetStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			// Call the function being tested
-			err := c.SetStatus(&ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
+			err := c.SetStatus(ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
 
 			// Use assert to check the equality of the error
 			if test.wantedError != nil {
@@ -397,7 +397,7 @@ func TestSetWebhook(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			c.cfg.GitProviderConfig = *test.config
 			// Call the function being tested
-			_, err := c.SetWebhook(&ctx, test.repo)
+			_, err := c.SetWebhook(ctx, test.repo)
 
 			// Use assert to check the equality of the error
 			if test.wantedError != nil {
@@ -482,7 +482,7 @@ func TestPingHook(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			c.cfg.GitProviderConfig = *test.config
 			// Call the function being tested
-			err := c.PingHook(&ctx, test.hook)
+			err := c.PingHook(ctx, test.hook)
 
 			// Use assert to check the equality of the error
 			if test.wantedError != nil {

--- a/pkg/git_provider/gitlab_test.go
+++ b/pkg/git_provider/gitlab_test.go
@@ -65,7 +65,7 @@ func TestGitlabListFiles(t *testing.T) {
 	ctx := context.Background()
 
 	// Execute
-	actualContent, err := c.ListFiles(&ctx, project, expectedRef, ".workflows")
+	actualContent, err := c.ListFiles(ctx, project, expectedRef, ".workflows")
 
 	var expectedFilesNames []string
 	for _, file := range treeNodes {
@@ -122,7 +122,7 @@ func TestGitlabGetFile(t *testing.T) {
 	ctx := context.Background()
 
 	// Execute
-	actualFile, err := c.GetFile(&ctx, project, branch, filePath)
+	actualFile, err := c.GetFile(ctx, project, branch, filePath)
 	// Assert
 	assert := assertion.New(t)
 	assert.NotNil(t, err)
@@ -247,7 +247,7 @@ func TestGitlabSetStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			// Call the function being tested
-			err := c.SetStatus(&ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
+			err := c.SetStatus(ctx, test.repo, test.commit, test.linkURL, test.status, test.message)
 
 			if test.wantedError != nil {
 				assert.NotNil(err)
@@ -365,7 +365,7 @@ func TestGitlabSetWebhook(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c.cfg.GitProviderConfig = test.config
-			_, err := c.SetWebhook(&ctx, &c.cfg.GitProviderConfig.RepoList)
+			_, err := c.SetWebhook(ctx, &c.cfg.GitProviderConfig.RepoList)
 
 			// Use assert to check the equality of the error
 			assert.Nil(err)

--- a/pkg/git_provider/gitlab_utils.go
+++ b/pkg/git_provider/gitlab_utils.go
@@ -42,9 +42,9 @@ func ValidateGitlabPermissions(ctx context.Context, client *gitlab.Client, cfg *
 	return fmt.Errorf("permissions error: %v is not a valid scope for the project level permissions", scopes)
 }
 
-func IsGroupWebhookEnabled(ctx *context.Context, c *GitlabClientImpl) (*gitlab.GroupHook, bool) {
+func IsGroupWebhookEnabled(ctx context.Context, c *GitlabClientImpl) (*gitlab.GroupHook, bool) {
 	emptyHook := gitlab.GroupHook{}
-	hooks, resp, err := c.client.Groups.ListGroupHooks(c.cfg.GitProviderConfig.OrgName, nil, gitlab.WithContext(*ctx))
+	hooks, resp, err := c.client.Groups.ListGroupHooks(c.cfg.GitProviderConfig.OrgName, nil, gitlab.WithContext(ctx))
 
 	if err != nil {
 		return &emptyHook, false
@@ -62,10 +62,10 @@ func IsGroupWebhookEnabled(ctx *context.Context, c *GitlabClientImpl) (*gitlab.G
 	return &emptyHook, false
 }
 
-func IsProjectWebhookEnabled(ctx *context.Context, c *GitlabClientImpl, projectId int) (*gitlab.ProjectHook, bool) {
+func IsProjectWebhookEnabled(ctx context.Context, c *GitlabClientImpl, projectId int) (*gitlab.ProjectHook, bool) {
 	emptyHook := gitlab.ProjectHook{}
 
-	hooks, resp, err := c.client.Projects.ListProjectHooks(projectId, nil, gitlab.WithContext(*ctx))
+	hooks, resp, err := c.client.Projects.ListProjectHooks(projectId, nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return &emptyHook, false
 	}
@@ -93,9 +93,9 @@ func ExtractLabelsId(labels []*gitlab.EventLabel) []string {
 	return returnLabelsList
 }
 
-func GetProjectId(ctx *context.Context, c *GitlabClientImpl, repo *string) (*int, error) {
+func GetProjectId(ctx context.Context, c *GitlabClientImpl, repo *string) (*int, error) {
 	projectFullName := fmt.Sprintf("%s/%s", c.cfg.GitProviderConfig.OrgName, *repo)
-	IProject, _, err := c.client.Projects.GetProject(projectFullName, nil, gitlab.WithContext(*ctx))
+	IProject, _, err := c.client.Projects.GetProject(projectFullName, nil, gitlab.WithContext(ctx))
 	if err != nil {
 		log.Printf("Failed to get project (%s): %v", *repo, err)
 		return nil, err

--- a/pkg/git_provider/gitlab_utils_test.go
+++ b/pkg/git_provider/gitlab_utils_test.go
@@ -96,7 +96,7 @@ func TestIsGroupWebhookEnabled(t *testing.T) {
 		mockHTTPResponse(t, w, hook)
 	})
 	// Execute
-	groupHook, isEnabled := IsGroupWebhookEnabled(&ctx, &c)
+	groupHook, isEnabled := IsGroupWebhookEnabled(ctx, &c)
 	// Assert
 	assert := assertion.New(t)
 	assert.Equal(isEnabled, true)
@@ -136,7 +136,7 @@ func TestIsProjectWebhookEnabled(t *testing.T) {
 	//
 	// Execute
 	//
-	projectHook, isEnabled := IsProjectWebhookEnabled(&ctx, &c, projectId)
+	projectHook, isEnabled := IsProjectWebhookEnabled(ctx, &c, projectId)
 	//
 	// Assert
 	//

--- a/pkg/git_provider/types.go
+++ b/pkg/git_provider/types.go
@@ -34,12 +34,12 @@ type WebhookPayload struct {
 }
 
 type Client interface {
-	ListFiles(ctx *context.Context, repo string, branch string, path string) ([]string, error)
-	GetFile(ctx *context.Context, repo string, branch string, path string) (*CommitFile, error)
-	GetFiles(ctx *context.Context, repo string, branch string, paths []string) ([]*CommitFile, error)
-	SetWebhook(ctx *context.Context, repo *string) (*HookWithStatus, error)
-	UnsetWebhook(ctx *context.Context, hook *HookWithStatus) error
-	HandlePayload(ctx *context.Context, request *http.Request, secret []byte) (*WebhookPayload, error)
-	SetStatus(ctx *context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error
-	PingHook(ctx *context.Context, hook *HookWithStatus) error
+	ListFiles(ctx context.Context, repo string, branch string, path string) ([]string, error)
+	GetFile(ctx context.Context, repo string, branch string, path string) (*CommitFile, error)
+	GetFiles(ctx context.Context, repo string, branch string, paths []string) ([]*CommitFile, error)
+	SetWebhook(ctx context.Context, repo *string) (*HookWithStatus, error)
+	UnsetWebhook(ctx context.Context, hook *HookWithStatus) error
+	HandlePayload(ctx context.Context, request *http.Request, secret []byte) (*WebhookPayload, error)
+	SetStatus(ctx context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error
+	PingHook(ctx context.Context, hook *HookWithStatus) error
 }

--- a/pkg/server/routes/healthz.go
+++ b/pkg/server/routes/healthz.go
@@ -19,7 +19,7 @@ func AddHealthRoutes(rg *gin.RouterGroup, wc *webhook_creator.WebhookCreatorImpl
 			ctx := c.Copy().Request.Context()
 			ctx2, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			err := wc.RunDiagnosis(&ctx2)
+			err := wc.RunDiagnosis(ctx2)
 			if err != nil {
 				log.Printf("error from healthz endpoint:%s\n", err)
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/pkg/server/routes/webhook.go
+++ b/pkg/server/routes/webhook.go
@@ -16,7 +16,7 @@ func AddWebhookRoutes(cfg *conf.GlobalConfig, clients *clients.Clients, rg *gin.
 
 	webhook.POST("", func(c *gin.Context) {
 		ctx := c.Request.Context()
-		webhookPayload, err := clients.GitProvider.HandlePayload(&ctx, c.Request, []byte(cfg.GitProviderConfig.WebhookSecret))
+		webhookPayload, err := clients.GitProvider.HandlePayload(ctx, c.Request, []byte(cfg.GitProviderConfig.WebhookSecret))
 		if err != nil {
 			log.Println(err)
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -41,7 +41,7 @@ func AddWebhookRoutes(cfg *conf.GlobalConfig, clients *clients.Clients, rg *gin.
 			return
 		}
 
-		workflowsBatches, err := webhookHandler.HandleWebhook(&ctx, wh)
+		workflowsBatches, err := webhookHandler.HandleWebhook(ctx, wh)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			log.Printf("failed to handle webhook, error: %v", err)
@@ -49,7 +49,7 @@ func AddWebhookRoutes(cfg *conf.GlobalConfig, clients *clients.Clients, rg *gin.
 		}
 
 		for _, wf := range workflowsBatches {
-			err = clients.Workflows.HandleWorkflowBatch(&ctx, wf)
+			err = clients.Workflows.HandleWorkflowBatch(ctx, wf)
 			if err != nil {
 				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				log.Printf("failed to handle workflow, error: %v", err)

--- a/pkg/server/shutdown.go
+++ b/pkg/server/shutdown.go
@@ -18,7 +18,7 @@ func NewGracefulShutdown(ctx context.Context, stop context.CancelFunc) *Graceful
 	}
 }
 
-func (s *GracefulShutdown) StopServices(ctx *context.Context, server *Server) {
+func (s *GracefulShutdown) StopServices(ctx context.Context, server *Server) {
 	server.webhookCreator.Stop(ctx)
 }
 
@@ -35,7 +35,7 @@ func (s *GracefulShutdown) Shutdown(server *Server) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	s.StopServices(&ctx, server)
+	s.StopServices(ctx, server)
 
 	err := server.httpServer.Shutdown(ctx)
 	if err != nil {

--- a/pkg/webhook_creator/main.go
+++ b/pkg/webhook_creator/main.go
@@ -97,7 +97,7 @@ func (wc *WebhookCreatorImpl) initWebhooks() error {
 		if wc.cfg.GitProviderConfig.Provider == "bitbucket" {
 			repo = utils.SanitizeString(repo)
 		}
-		hook, err := wc.clients.GitProvider.SetWebhook(&ctx, &repo)
+		hook, err := wc.clients.GitProvider.SetWebhook(ctx, &repo)
 		if err != nil {
 			return err
 		}
@@ -107,7 +107,7 @@ func (wc *WebhookCreatorImpl) initWebhooks() error {
 	return nil
 }
 
-func (wc *WebhookCreatorImpl) Stop(ctx *context.Context) {
+func (wc *WebhookCreatorImpl) Stop(ctx context.Context) {
 	if wc.cfg.GitProviderConfig.WebhookAutoCleanup {
 		err := wc.deleteWebhooks(ctx)
 		if err != nil {
@@ -116,7 +116,7 @@ func (wc *WebhookCreatorImpl) Stop(ctx *context.Context) {
 	}
 }
 
-func (wc *WebhookCreatorImpl) deleteWebhooks(ctx *context.Context) error {
+func (wc *WebhookCreatorImpl) deleteWebhooks(ctx context.Context) error {
 	for hookID, hook := range wc.hooks {
 		err := wc.clients.GitProvider.UnsetWebhook(ctx, hook)
 		if err != nil {
@@ -154,7 +154,7 @@ func (wc *WebhookCreatorImpl) checkHooksHealth(timeoutSeconds time.Duration) boo
 	return false
 }
 
-func (wc *WebhookCreatorImpl) recoverHook(ctx *context.Context, hookID int64) error {
+func (wc *WebhookCreatorImpl) recoverHook(ctx context.Context, hookID int64) error {
 
 	log.Printf("started recover of hook %d", hookID)
 	hook := wc.getWebhook(hookID)
@@ -172,7 +172,7 @@ func (wc *WebhookCreatorImpl) recoverHook(ctx *context.Context, hookID int64) er
 
 }
 
-func (wc *WebhookCreatorImpl) pingHooks(ctx *context.Context) error {
+func (wc *WebhookCreatorImpl) pingHooks(ctx context.Context) error {
 	for _, hook := range wc.hooks {
 		err := wc.clients.GitProvider.PingHook(ctx, hook)
 		if err != nil {
@@ -182,7 +182,7 @@ func (wc *WebhookCreatorImpl) pingHooks(ctx *context.Context) error {
 	return nil
 }
 
-func (wc *WebhookCreatorImpl) RunDiagnosis(ctx *context.Context) error {
+func (wc *WebhookCreatorImpl) RunDiagnosis(ctx context.Context) error {
 	log.Printf("Starting webhook diagnostics")
 	wc.setAllHooksHealth(false)
 	err := wc.pingHooks(ctx)

--- a/pkg/webhook_creator/mocks.go
+++ b/pkg/webhook_creator/mocks.go
@@ -1,6 +1,7 @@
 package webhook_creator
 
 import (
+	context2 "context"
 	"errors"
 	"github.com/quickube/piper/pkg/git_provider"
 	"golang.org/x/net/context"
@@ -18,58 +19,58 @@ type MockGitProviderClient struct {
 	PingHookFunc      func(ctx context.Context, hook *git_provider.HookWithStatus) error
 }
 
-func (m *MockGitProviderClient) ListFiles(ctx *context.Context, repo string, branch string, path string) ([]string, error) {
+func (m *MockGitProviderClient) ListFiles(ctx context2.Context, repo string, branch string, path string) ([]string, error) {
 	if m.ListFilesFunc != nil {
-		return m.ListFilesFunc(*ctx, repo, branch, path)
+		return m.ListFilesFunc(ctx, repo, branch, path)
 	}
 	return nil, errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) GetFile(ctx *context.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
+func (m *MockGitProviderClient) GetFile(ctx context2.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
 	if m.GetFileFunc != nil {
-		return m.GetFileFunc(*ctx, repo, branch, path)
+		return m.GetFileFunc(ctx, repo, branch, path)
 	}
 	return nil, errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) GetFiles(ctx *context.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
+func (m *MockGitProviderClient) GetFiles(ctx context2.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
 	if m.GetFilesFunc != nil {
-		return m.GetFilesFunc(*ctx, repo, branch, paths)
+		return m.GetFilesFunc(ctx, repo, branch, paths)
 	}
 	return nil, errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) SetWebhook(ctx *context.Context, repo *string) (*git_provider.HookWithStatus, error) {
+func (m *MockGitProviderClient) SetWebhook(ctx context2.Context, repo *string) (*git_provider.HookWithStatus, error) {
 	if m.SetWebhookFunc != nil {
-		return m.SetWebhookFunc(*ctx, repo)
+		return m.SetWebhookFunc(ctx, repo)
 	}
 	return nil, errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) UnsetWebhook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *MockGitProviderClient) UnsetWebhook(ctx context2.Context, hook *git_provider.HookWithStatus) error {
 	if m.UnsetWebhookFunc != nil {
-		return m.UnsetWebhookFunc(*ctx, hook)
+		return m.UnsetWebhookFunc(ctx, hook)
 	}
 	return errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) HandlePayload(ctx *context.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
+func (m *MockGitProviderClient) HandlePayload(ctx context2.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
 	if m.HandlePayloadFunc != nil {
 		return m.HandlePayloadFunc(request, secret)
 	}
 	return nil, errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) SetStatus(ctx *context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
+func (m *MockGitProviderClient) SetStatus(ctx context2.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
 	if m.SetStatusFunc != nil {
-		return m.SetStatusFunc(*ctx, repo, commit, linkURL, status, message)
+		return m.SetStatusFunc(ctx, repo, commit, linkURL, status, message)
 	}
 	return errors.New("unimplemented")
 }
 
-func (m *MockGitProviderClient) PingHook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *MockGitProviderClient) PingHook(ctx context2.Context, hook *git_provider.HookWithStatus) error {
 	if m.PingHookFunc != nil {
-		return m.PingHookFunc(*ctx, hook)
+		return m.PingHookFunc(ctx, hook)
 	}
 	return errors.New("unimplemented")
 }

--- a/pkg/webhook_creator/tests_test.go
+++ b/pkg/webhook_creator/tests_test.go
@@ -184,7 +184,7 @@ func TestWebhookCreatorImpl_Stop(t *testing.T) {
 
 	// Stop the webhook creator
 	ctx := context.Background()
-	wc.Stop(&ctx)
+	wc.Stop(ctx)
 
 	// Verify that the webhook was deleted
 	hook := wc.getWebhook(hookID)
@@ -216,7 +216,7 @@ func TestWebhookCreatorImpl_DeleteWebhooks(t *testing.T) {
 
 	// Delete the webhooks
 	ctx := context.Background()
-	err := wc.deleteWebhooks(&ctx)
+	err := wc.deleteWebhooks(ctx)
 	assertion.NoError(err)
 
 	// Verify that all webhooks were deleted
@@ -279,7 +279,7 @@ func TestWebhookCreatorImpl_RecoverHook(t *testing.T) {
 
 	// Recover the webhook
 	ctx := context.Background()
-	err := wc.recoverHook(&ctx, hookID)
+	err := wc.recoverHook(ctx, hookID)
 	assertion.Nil(err)
 
 	// Verify that the webhook was recovered
@@ -328,7 +328,7 @@ func TestWebhookCreatorImpl_PingHooks(t *testing.T) {
 
 	// Ping the webhooks
 	ctx := context.Background()
-	err := wc.pingHooks(&ctx)
+	err := wc.pingHooks(ctx)
 	assertion.NotNil(err)
 }
 
@@ -364,7 +364,7 @@ func TestWebhookCreatorImpl_RunDiagnosis(t *testing.T) {
 
 	// Run the webhook diagnosis
 	ctx := context.Background()
-	err := wc.RunDiagnosis(&ctx)
+	err := wc.RunDiagnosis(ctx)
 	assertion.NotNil(err)
 
 }

--- a/pkg/webhook_handler/types.go
+++ b/pkg/webhook_handler/types.go
@@ -15,6 +15,6 @@ type Trigger struct {
 }
 
 type WebhookHandler interface {
-	RegisterTriggers(ctx *context.Context) error
-	PrepareBatchForMatchingTriggers(ctx *context.Context) ([]*common.WorkflowsBatch, error)
+	RegisterTriggers(ctx context.Context) error
+	PrepareBatchForMatchingTriggers(ctx context.Context) ([]*common.WorkflowsBatch, error)
 }

--- a/pkg/webhook_handler/webhook_handler.go
+++ b/pkg/webhook_handler/webhook_handler.go
@@ -30,7 +30,7 @@ func NewWebhookHandler(cfg *conf.GlobalConfig, clients *clients.Clients, payload
 	}, err
 }
 
-func (wh *WebhookHandlerImpl) RegisterTriggers(ctx *context.Context) error {
+func (wh *WebhookHandlerImpl) RegisterTriggers(ctx context.Context) error {
 	if !IsFileExists(ctx, wh, "", ".workflows") {
 		return fmt.Errorf(".workflows folder does not exist in %s/%s", wh.Payload.Repo, wh.Payload.Branch)
 	}
@@ -53,7 +53,7 @@ func (wh *WebhookHandlerImpl) RegisterTriggers(ctx *context.Context) error {
 	return nil
 }
 
-func (wh *WebhookHandlerImpl) PrepareBatchForMatchingTriggers(ctx *context.Context) ([]*common.WorkflowsBatch, error) {
+func (wh *WebhookHandlerImpl) PrepareBatchForMatchingTriggers(ctx context.Context) ([]*common.WorkflowsBatch, error) {
 	triggered := false
 	var workflowBatches []*common.WorkflowsBatch
 	for _, trigger := range *wh.Triggers {
@@ -155,7 +155,7 @@ func (wh *WebhookHandlerImpl) PrepareBatchForMatchingTriggers(ctx *context.Conte
 	return workflowBatches, nil
 }
 
-func IsFileExists(ctx *context.Context, wh *WebhookHandlerImpl, path string, file string) bool {
+func IsFileExists(ctx context.Context, wh *WebhookHandlerImpl, path string, file string) bool {
 	files, err := wh.clients.GitProvider.ListFiles(ctx, wh.Payload.Repo, wh.Payload.Branch, path)
 	if err != nil {
 		log.Printf("Error listing files in repo: %s branch: %s. %v", wh.Payload.Repo, wh.Payload.Branch, err)
@@ -173,7 +173,7 @@ func IsFileExists(ctx *context.Context, wh *WebhookHandlerImpl, path string, fil
 	return false
 }
 
-func HandleWebhook(ctx *context.Context, wh *WebhookHandlerImpl) ([]*common.WorkflowsBatch, error) {
+func HandleWebhook(ctx context.Context, wh *WebhookHandlerImpl) ([]*common.WorkflowsBatch, error) {
 	err := wh.RegisterTriggers(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to register triggers, error: %v", err)

--- a/pkg/webhook_handler/webhook_handler_test.go
+++ b/pkg/webhook_handler/webhook_handler_test.go
@@ -41,7 +41,7 @@ var commitFileMap = map[string]*git_provider.CommitFile{
 // mockGitProvider is a mock implementation of the git_provider.Client interface.
 type mockGitProvider struct{}
 
-func (m *mockGitProvider) GetFile(ctx *context.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
+func (m *mockGitProvider) GetFile(ctx context.Context, repo string, branch string, path string) (*git_provider.CommitFile, error) {
 
 	fullPath := fmt.Sprintf("%s/%s/%s", repo, branch, path)
 	if fileInfo, ok := commitFileMap[fullPath]; ok {
@@ -50,7 +50,7 @@ func (m *mockGitProvider) GetFile(ctx *context.Context, repo string, branch stri
 	return &git_provider.CommitFile{}, nil
 }
 
-func (m *mockGitProvider) GetFiles(ctx *context.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
+func (m *mockGitProvider) GetFiles(ctx context.Context, repo string, branch string, paths []string) ([]*git_provider.CommitFile, error) {
 	var commitFiles []*git_provider.CommitFile
 
 	for _, path := range paths {
@@ -65,7 +65,7 @@ func (m *mockGitProvider) GetFiles(ctx *context.Context, repo string, branch str
 
 }
 
-func (m *mockGitProvider) ListFiles(ctx *context.Context, repo string, branch string, path string) ([]string, error) {
+func (m *mockGitProvider) ListFiles(ctx context.Context, repo string, branch string, path string) ([]string, error) {
 	var files []string
 
 	fullPath := fmt.Sprintf("%s/%s/%s/", repo, branch, path)
@@ -80,23 +80,23 @@ func (m *mockGitProvider) ListFiles(ctx *context.Context, repo string, branch st
 	return files, nil
 }
 
-func (m *mockGitProvider) SetWebhook(ctx *context.Context, repo *string) (*git_provider.HookWithStatus, error) {
+func (m *mockGitProvider) SetWebhook(ctx context.Context, repo *string) (*git_provider.HookWithStatus, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) UnsetWebhook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *mockGitProvider) UnsetWebhook(ctx context.Context, hook *git_provider.HookWithStatus) error {
 	return nil
 }
 
-func (m *mockGitProvider) HandlePayload(ctx *context.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
+func (m *mockGitProvider) HandlePayload(ctx context.Context, request *http.Request, secret []byte) (*git_provider.WebhookPayload, error) {
 	return nil, nil
 }
 
-func (m *mockGitProvider) SetStatus(ctx *context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
+func (m *mockGitProvider) SetStatus(ctx context.Context, repo *string, commit *string, linkURL *string, status *string, message *string) error {
 	return nil
 }
 
-func (m *mockGitProvider) PingHook(ctx *context.Context, hook *git_provider.HookWithStatus) error {
+func (m *mockGitProvider) PingHook(ctx context.Context, hook *git_provider.HookWithStatus) error {
 	return nil
 }
 
@@ -497,7 +497,7 @@ func TestPrepareBatchForMatchingTriggers(t *testing.T) {
 					GitProvider: &mockGitProvider{},
 				},
 			}
-			WorkflowsBatches, err := wh.PrepareBatchForMatchingTriggers(&ctx)
+			WorkflowsBatches, err := wh.PrepareBatchForMatchingTriggers(ctx)
 			if test.expectedWorkflowBatch == nil {
 				assert.Nil(WorkflowsBatches)
 				assert.NotNil(err)

--- a/pkg/workflow_handler/types.go
+++ b/pkg/workflow_handler/types.go
@@ -14,8 +14,8 @@ type WorkflowsClient interface {
 	CreateWorkflow(spec *v1alpha1.WorkflowSpec, workflowsBatch *common.WorkflowsBatch) (*v1alpha1.Workflow, error)
 	SelectConfig(workflowsBatch *common.WorkflowsBatch) (string, error)
 	Lint(wf *v1alpha1.Workflow) error
-	Submit(ctx *context.Context, wf *v1alpha1.Workflow) error
-	HandleWorkflowBatch(ctx *context.Context, workflowsBatch *common.WorkflowsBatch) error
-	Watch(ctx *context.Context, labelSelector *metav1.LabelSelector) (watch.Interface, error)
-	UpdatePiperWorkflowLabel(ctx *context.Context, workflowName string, label string, value string) error
+	Submit(ctx context.Context, wf *v1alpha1.Workflow) error
+	HandleWorkflowBatch(ctx context.Context, workflowsBatch *common.WorkflowsBatch) error
+	Watch(ctx context.Context, labelSelector *metav1.LabelSelector) (watch.Interface, error)
+	UpdatePiperWorkflowLabel(ctx context.Context, workflowName string, label string, value string) error
 }

--- a/pkg/workflow_handler/workflows.go
+++ b/pkg/workflow_handler/workflows.go
@@ -99,10 +99,10 @@ func (wfc *WorkflowsClientImpl) CreateWorkflow(spec *v1alpha1.WorkflowSpec, work
 			Namespace:    wfc.cfg.Namespace,
 			Labels: map[string]string{
 				"piper.quickube.com/notified": "false",
-				"repo":                       ConvertToValidString(workflowsBatch.Payload.Repo),
-				"branch":                     ConvertToValidString(workflowsBatch.Payload.Branch),
-				"user":                       ConvertToValidString(workflowsBatch.Payload.User),
-				"commit":                     ConvertToValidString(workflowsBatch.Payload.Commit),
+				"repo":                        ConvertToValidString(workflowsBatch.Payload.Repo),
+				"branch":                      ConvertToValidString(workflowsBatch.Payload.Branch),
+				"user":                        ConvertToValidString(workflowsBatch.Payload.User),
+				"commit":                      ConvertToValidString(workflowsBatch.Payload.Commit),
 			},
 		},
 		Spec: *spec,
@@ -144,9 +144,9 @@ func (wfc *WorkflowsClientImpl) Lint(wf *v1alpha1.Workflow) error {
 	panic("implement me")
 }
 
-func (wfc *WorkflowsClientImpl) Submit(ctx *context.Context, wf *v1alpha1.Workflow) error {
+func (wfc *WorkflowsClientImpl) Submit(ctx context.Context, wf *v1alpha1.Workflow) error {
 	workflowsClient := wfc.clientSet.ArgoprojV1alpha1().Workflows(wfc.cfg.Namespace)
-	_, err := workflowsClient.Create(*ctx, wf, metav1.CreateOptions{})
+	_, err := workflowsClient.Create(ctx, wf, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func (wfc *WorkflowsClientImpl) Submit(ctx *context.Context, wf *v1alpha1.Workfl
 	return nil
 }
 
-func (wfc *WorkflowsClientImpl) HandleWorkflowBatch(ctx *context.Context, workflowsBatch *common.WorkflowsBatch) error {
+func (wfc *WorkflowsClientImpl) HandleWorkflowBatch(ctx context.Context, workflowsBatch *common.WorkflowsBatch) error {
 	var params []v1alpha1.Parameter
 
 	configName, err := wfc.SelectConfig(workflowsBatch)
@@ -209,13 +209,13 @@ func (wfc *WorkflowsClientImpl) HandleWorkflowBatch(ctx *context.Context, workfl
 	return nil
 }
 
-func (wfc *WorkflowsClientImpl) Watch(ctx *context.Context, labelSelector *metav1.LabelSelector) (watch.Interface, error) {
+func (wfc *WorkflowsClientImpl) Watch(ctx context.Context, labelSelector *metav1.LabelSelector) (watch.Interface, error) {
 	workflowsClient := wfc.clientSet.ArgoprojV1alpha1().Workflows(wfc.cfg.Namespace)
 	opts := v1.ListOptions{
 		Watch:         true,
 		LabelSelector: metav1.FormatLabelSelector(labelSelector),
 	}
-	watcher, err := workflowsClient.Watch(*ctx, opts)
+	watcher, err := workflowsClient.Watch(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (wfc *WorkflowsClientImpl) Watch(ctx *context.Context, labelSelector *metav
 	return watcher, nil
 }
 
-func (wfc *WorkflowsClientImpl) UpdatePiperWorkflowLabel(ctx *context.Context, workflowName string, label string, value string) error {
+func (wfc *WorkflowsClientImpl) UpdatePiperWorkflowLabel(ctx context.Context, workflowName string, label string, value string) error {
 	workflowsClient := wfc.clientSet.ArgoprojV1alpha1().Workflows(wfc.cfg.Namespace)
 
 	patch, err := json.Marshal(map[string]interface{}{"metadata": metav1.ObjectMeta{
@@ -234,7 +234,7 @@ func (wfc *WorkflowsClientImpl) UpdatePiperWorkflowLabel(ctx *context.Context, w
 	if err != nil {
 		return err
 	}
-	_, err = workflowsClient.Patch(*ctx, workflowName, types.MergePatchType, patch, v1.PatchOptions{})
+	_, err = workflowsClient.Patch(ctx, workflowName, types.MergePatchType, patch, v1.PatchOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Pull Request

### Description

context.Context is immutable:
The context.Context type and its implementations (e.g., context.Background(), context.WithCancel, context.WithTimeout) are immutable. Each operation that modifies a context (e.g., adding a deadline or attaching values) returns a new context.
This immutability means you can safely pass a context.Context by value without worrying about unintended side effects.

Interface Semantics:
context.Context is an interface, not a struct. When you pass it, you are effectively passing a pointer to the underlying implementation, even though it appears to be passed by value. This makes passing it by pointer unnecessary.

### Checklist

Before submitting this pull request, please ensure that you have completed the following tasks:

- [x] Reviewed the [Contributing Guidelines](../docs/CONTRIBUTING.md) for the Piper project.
- [x] Ensured that your changes follow the [coding guidelines and style](../docs/CONTRIBUTING.md#coding-guidelines) of the project.
- [x] Run the tests locally and made sure they pass.
- [x] Updated the relevant documentation, if applicable.