### PR TITLE
fix: event handler listen to ctx.Done

### DIFF
--- a/cmd/piper/piper.go
+++ b/cmd/piper/piper.go
@@ -51,6 +51,6 @@ func main() {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	event_handler.Start(ctx, stop, cfg, globalClients)
+	event_handler.Start(ctx, cfg, globalClients)
 	server.Start(ctx, stop, cfg, globalClients)
 }

--- a/cmd/piper/piper.go
+++ b/cmd/piper/piper.go
@@ -51,6 +51,6 @@ func main() {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	event_handler.Start(ctx, cfg, globalClients)
+	event_handler.Start(ctx, stop, cfg, globalClients)
 	server.Start(ctx, stop, cfg, globalClients)
 }

--- a/pkg/event_handler/main.go
+++ b/pkg/event_handler/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 )
 
-func Start(ctx context.Context, cfg *conf.GlobalConfig, clients *clients.Clients) {
+func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig, clients *clients.Clients) {
 	labelSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: "piper.quickube.com/notified",
@@ -37,6 +37,7 @@ func Start(ctx context.Context, cfg *conf.GlobalConfig, clients *clients.Clients
 				if !ok {
 					log.Print("[event handler] result channel closed")
 					watcher.Stop()
+					stop()
 					return
 				}
 				if err2 := handler.Handle(ctx, &event); err2 != nil {

--- a/pkg/event_handler/main.go
+++ b/pkg/event_handler/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 )
 
-func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig, clients *clients.Clients) {
+func Start(ctx context.Context, cfg *conf.GlobalConfig, clients *clients.Clients) {
 	labelSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{Key: "piper.quickube.com/notified",
@@ -43,7 +43,6 @@ func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig,
 					log.Printf("[event handler] failed to Handle workflow event: %v", err2)
 				}
 			}
-			stop()
 		}
 
 	}()

--- a/pkg/event_handler/main.go
+++ b/pkg/event_handler/main.go
@@ -27,19 +27,17 @@ func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig,
 		Notifier: notifier,
 	}
 	go func() {
-		defer func() {
-			log.Print("[event handler] shutting down, stopping watcher")
-			watcher.Stop()
-		}()
 
 		for {
 			select {
 			case <-ctx.Done():
 				log.Print("[event handler] context canceled, exiting")
+				watcher.Stop()
 				return
 			case event, ok := <-watcher.ResultChan():
 				if !ok {
 					log.Print("[event handler] result channel closed")
+					stop()
 					return
 				}
 				if err2 := handler.Handle(ctx, &event); err2 != nil {

--- a/pkg/event_handler/main.go
+++ b/pkg/event_handler/main.go
@@ -27,14 +27,24 @@ func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig,
 		Notifier: notifier,
 	}
 	go func() {
-		for event := range watcher.ResultChan() {
-			err2 := handler.Handle(ctx, &event)
-			if err2 != nil {
-				log.Printf("[event handler] failed to Handle workflow event %s", err2) // ERROR
+		for {
+			select {
+			case <-ctx.Done():
+				log.Print("[event handler] context canceled, stopping watcher")
+				watcher.Stop()
+				return
+			case event, ok := <-watcher.ResultChan():
+				if !ok {
+					log.Print("[event handler] result channel closed")
+					watcher.Stop()
+					return
+				}
+				if err2 := handler.Handle(ctx, &event); err2 != nil {
+					log.Printf("[event handler] failed to Handle workflow event: %v", err2)
+				}
 			}
+			stop()
 		}
-		log.Print("[event handler] stopped work, closing watcher")
-		watcher.Stop()
-		stop()
+
 	}()
 }


### PR DESCRIPTION
## Pull Request

### Description

Possible race condition on watcher.Stop() and stop()
Added listen to closure of watcher channel and stop the program 

Before submitting this pull request, please ensure that you have completed the following tasks:

- [x] Reviewed the [Contributing Guidelines](../docs/CONTRIBUTING.md) for the Piper project.
- [x] Ensured that your changes follow the [coding guidelines and style](../docs/CONTRIBUTING.md#coding-guidelines) of the project.
- [x] Run the tests locally and made sure they pass.
- [x] Updated the relevant documentation, if applicable.