### PR TITLE
fix: add context to webhook creator

### DIFF
--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -11,7 +11,7 @@ func Start(ctx context.Context, stop context.CancelFunc, cfg *conf.GlobalConfig,
 
 	srv := NewServer(cfg, clients)
 	gracefulShutdownHandler := NewGracefulShutdown(ctx, stop)
-	srv.Start()
+	srv.Start(ctx)
 
 	gracefulShutdownHandler.Shutdown(srv)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"github.com/gin-gonic/gin"
 	"github.com/quickube/piper/pkg/clients"
 	"github.com/quickube/piper/pkg/conf"
@@ -28,6 +29,7 @@ func (s *Server) startServer() *http.Server {
 	}
 
 	go func() {
+		log.Printf("Server is listening on %s", s.httpServer.Addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("listen: %s\n", err)
 		}
@@ -53,11 +55,11 @@ func (s *Server) getRoutes() {
 	routes.AddWebhookRoutes(s.config, s.clients, v1, s.webhookCreator)
 }
 
-func (s *Server) startServices() {
-	s.webhookCreator.Start()
+func (s *Server) startServices(ctx context.Context) {
+	s.webhookCreator.Start(ctx)
 }
 
-func (s *Server) Start() {
+func (s *Server) Start(ctx context.Context) {
 
 	s.registerMiddlewares()
 
@@ -65,6 +67,6 @@ func (s *Server) Start() {
 
 	s.httpServer = s.startServer()
 
-	s.startServices()
+	s.startServices(ctx)
 
 }

--- a/pkg/webhook_creator/main.go
+++ b/pkg/webhook_creator/main.go
@@ -35,9 +35,9 @@ func (wc *WebhookCreatorImpl) GetHooks() *map[int64]*git_provider.HookWithStatus
 	return &wc.hooks
 }
 
-func (wc *WebhookCreatorImpl) Start() {
+func (wc *WebhookCreatorImpl) Start(ctx context.Context) {
 
-	err := wc.initWebhooks()
+	err := wc.initWebhooks(ctx)
 	if err != nil {
 		log.Print(err)
 		panic("failed in initializing webhooks")
@@ -85,9 +85,8 @@ func (wc *WebhookCreatorImpl) setAllHooksHealth(status bool) {
 	log.Printf("set all hooks health status for to %s", strconv.FormatBool(status))
 }
 
-func (wc *WebhookCreatorImpl) initWebhooks() error {
+func (wc *WebhookCreatorImpl) initWebhooks(ctx context.Context) error {
 
-	ctx := context.Background()
 	if wc.cfg.GitProviderConfig.OrgLevelWebhook && len(wc.cfg.GitProviderConfig.RepoList) != 0 {
 		return fmt.Errorf("org level webhook wanted but provided repositories list")
 	} else if !wc.cfg.GitProviderConfig.OrgLevelWebhook && len(wc.cfg.GitProviderConfig.RepoList) == 0 {

--- a/pkg/webhook_creator/tests_test.go
+++ b/pkg/webhook_creator/tests_test.go
@@ -126,6 +126,7 @@ func TestWebhookCreatorImpl_SetAllHooksHealth(t *testing.T) {
 
 func TestWebhookCreatorImpl_InitWebhooks(t *testing.T) {
 	assertion := assert.New(t)
+	ctx := context.Background()
 	// Mock the necessary methods of the GitProvider client
 	mockClient := &MockGitProviderClient{
 		SetWebhookFunc: func(ctx context.Context, repoName *string) (*git_provider.HookWithStatus, error) {
@@ -149,7 +150,7 @@ func TestWebhookCreatorImpl_InitWebhooks(t *testing.T) {
 	})
 
 	// Initialize the webhooks
-	err := wc.initWebhooks()
+	err := wc.initWebhooks(ctx)
 
 	// Run tests
 	assertion.NoError(err)


### PR DESCRIPTION
## Pull Request

### Description

Webhook creation happens on startup. If Piper gets signal for termination, it will not cancel this request.

### Checklist

Before submitting this pull request, please ensure that you have completed the following tasks:

- [x] Reviewed the [Contributing Guidelines](../docs/CONTRIBUTING.md) for the Piper project.
- [x] Ensured that your changes follow the [coding guidelines and style](../docs/CONTRIBUTING.md#coding-guidelines) of the project.
- [x] Run the tests locally and made sure they pass.
- [x] Updated the relevant documentation, if applicable.